### PR TITLE
Upgrade SW sync to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,11 +2432,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
         "cliui": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -7126,9 +7121,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -7325,9 +7320,9 @@
       }
     },
     "skiller-whale-sync": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/skiller-whale-sync/-/skiller-whale-sync-1.4.0.tgz",
-      "integrity": "sha512-186RqKtbRSOQ1KnOIl2UKkmjNv+RdR7la3Dkz/PrXhvzvMuQPL/4DQPKR4MH6769EeQ9EOtOSFh5AkGSe2RUUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/skiller-whale-sync/-/skiller-whale-sync-1.5.0.tgz",
+      "integrity": "sha512-FZiHd+5kWNg0oYR+WqY0N6JfAP42948TO0Nlxp7najzpf03RDfvPA0VjPiVjEIBkJJ03hUrJd/Yg1C5XWxVMaA==",
       "requires": {
         "concurrently": "^4.1.0",
         "cross-spawn": "^6.0.5"
@@ -7796,9 +7791,9 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-fest": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-native-gesture-handler": "^1.6.1",
     "react-navigation": "^3.11.0",
     "react-navigation-stack": "^1.9.0",
-    "skiller-whale-sync": "^1.4.0"
+    "skiller-whale-sync": "^1.5.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0"


### PR DESCRIPTION
This upgrades `skiller-whale-sync` to `1.5.0`. It also removes `camelcase` and upgrades `tslib` and `rsjx`.
